### PR TITLE
add OMSF Code of Conduct

### DIFF
--- a/content/conduct.md
+++ b/content/conduct.md
@@ -1,0 +1,76 @@
+---
+title: "OMSF Code of Conduct"
+name: "conduct"
+weight: 1
+---
+
+
+#### CODE OF CONDUCT
+
+This Code of Conduct is based on the (Apache Foundation Code of Conduct)[https://www.apache.org/foundation/policies/conduct.html] and modified accordingly.
+
+Last modified: June 2, 2022.
+
+#### INTRODUCTION
+
+This code of conduct applies to all spaces the Open Molecular Software Foundation manages, including IRC, public and private mailing lists, issue trackers, wikis, blogs, Twitter, and any other communication channels our communities use.
+We expect everyone who participates in the OMSF communities formally or informally, or claims any affiliation with OMSF, in any OMSF-related activities and especially when representing the OMSF in any role to honor this code of conduct.
+This code is not exhaustive or complete. It distills our common understanding of a collaborative, shared environment and goals. We expect all members of the OMSF communities to follow it in spirit as much as in the letter, so that it can enrich all of us and the technical communities in which we participate.
+
+
+#### SPECIFIC GUIDELINES
+
+We strive to:
+**Be open.** We invite anyone to participate in our community. Please use public methods of communication for project-related messages, unless discussing something sensitive. This applies to messages for help or project-related support, too; not only is a public support request much more likely to result in an answer to a question, it also makes sure that any member of the community notices and corrects any inadvertent mistakes people answering the query may make.
+
+**Be empathetic, welcoming, friendly, and patient.** We work together to resolve conflicts, assume good intentions, and do our best to act in an empathetic fashion. We may all experience some frustration from time to time, but we do not allow frustration to result in a personal attack. A community where people feel uncomfortable or threatened is not a productive one. We should be respectful when dealing with other community members as well as with people outside our community.
+
+**Be collaborative.** Other people will use our work, and we in turn depend on the work of others. When we make something for the benefit of the project, we are willing to explain to others how it works, so they can build on the work to make it even better. Any decision we make will affect users and colleagues, and we take those consequences seriously when making decisions.
+
+**Be inquisitive.** Nobody knows everything! Asking questions early avoids many problems later, so we encourage questions, although we may redirect them to the appropriate forum. Those who receive a question should be responsive and helpful, within the context of our shared goal of improving Apache project code.
+
+**Be careful in the words that we choose.** Whether we are participating as professionals or volunteers, we value professionalism in all interactions, and take responsibility for our own speech. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behaviour are not acceptable. This includes, but is not limited to:
+* Violent threats or language directed against another person.
+* Sexist, racist, or otherwise discriminatory jokes and language.
+* Posting sexually explicit or violent material.
+* Posting (or threatening to post) other people's personally identifying information ("doxing").
+* Sharing private content, such as emails sent privately or non-publicly, or from unlogged forums such as IRC channel history.
+* Personal insults, especially those using racist or sexist terms.
+* Unwelcome sexual attention.
+* Excessive or unnecessary profanity.
+* Repeated harassment of others. In general, if someone asks you to stop, then stop.
+* Advocating for, or encouraging, any of the above behaviour.
+
+**Be concise.** Keep in mind that, over time, hundreds or thousands of people will read what you write. Writing a short email means people can understand the conversation as efficiently as possible. Short emails should always strive to be empathetic, welcoming, friendly and patient. When a long explanation is necessary, consider adding a summary at the top of the message.
+
+Try to bring new ideas to a conversation so that each email adds something unique to the thread, keeping in mind that the rest of the thread still contains the other messages with arguments that have already been made.
+
+Try to stay on topic, especially in discussions that are already fairly long.
+Step down considerately. Members of every project come and go. When somebody leaves or disengages from the project they should tell people they are leaving and take the proper steps to ensure that others can pick up where they left off. In doing so, they should remain respectful of those who continue to participate in the project and should not misrepresent the project's goals or achievements. Likewise, community members should respect any individual's choice to leave the project.
+
+
+#### DIVERSITY STATEMENT
+
+OMSF welcomes and encourages participation by everyone. We are committed to being a community that everyone feels good about joining. Although we may not be able to satisfy everyone, we will always work to treat everyone well.
+No matter how you identify yourself or how others perceive you, we welcome you. Though no list can hope to be comprehensive, we explicitly honour diversity in age, culture, ethnicity, genotype, gender identity or expression, language, national origin, neurotype, phenotype, political beliefs, profession, race, religion, sexual orientation, socioeconomic status, subculture and technical ability.
+Though we welcome people fluent in all languages, OMSF project development takes place in English.
+The Code of Conduct, above, details our standards for behaviour in the OMSF community. We expect participants in our community to meet these standards in all their interactions and to help others to do so.
+
+#### REPORTING GUIDELINES
+
+While all participants should adhere to this code of conduct, we recognize that sometimes people may have a bad day, or be unaware of some of the code's guidelines. When that happens, you may reply to them and point out this code of conduct. Such messages may be in public or in private, whatever is most appropriate. However, regardless of whether the message is public or not, it should still adhere to the relevant parts of this code of conduct; in particular, it should not be abusive or disrespectful.
+Assume good faith; it is more likely that participants are unaware of their bad behaviour than that they intentionally try to degrade the quality of the discussion. Should there be difficulties in dealing with the situation, you may report your compliance issues in confidence to board at omsf.io or director @ omsf.io
+If the violation is in documentation or code, for example inappropriate pronoun usage or word choice within official documentation, report these privately to the project in question at their contact email addresses, and, if you have sufficient ability within the project, resolve or remove the concerning material, being mindful of the perspective of the person originally reporting the issue.
+
+#### NOTES
+This Code defines empathy as "a vicarious participation in the emotions, ideas, or opinions of others; the ability to imagine oneself in the condition or predicament of another." Empathetic is the adjectival form of empathy.
+This statement draws on the following for content and inspiration:
+- CouchDB Project Code of conduct
+- Fedora Project Code of Conduct
+- Speak Up! Code of Conduct
+- Django Code of Conduct
+- Debian Code of Conduct
+- Twitter Open Source Code of Conduct
+- Mozilla Code of Conduct/Draft
+- Python Diversity Appendix
+- Python Mentors Home Page


### PR DESCRIPTION
OMSF Code of Conduct is based on the Apache Foundation Code of Conduct. 