### PR TITLE
add link to CoC on Docs page

### DIFF
--- a/content/about/legal/index.md
+++ b/content/about/legal/index.md
@@ -18,6 +18,7 @@ Incorporation & Bylaws
 Policies
 {{% /h3-green %}}
 ###### [Antitrust Policy](/antitrust-policy)
+###### [Code of Conduct](/conduct)
 ###### [Conflict of Interest Policy](/coi-policy)
 ###### [Good standing Policy](/good-standing-policy)
 ###### [Privacy Policy](/privacy-policy)


### PR DESCRIPTION
Added link for Code of Conduct to https://omsf.io/about/legal/.