### PR TITLE
Remove form link on host-project/Remove OpenFold job ad

### DIFF
--- a/content/about/careers.md
+++ b/content/about/careers.md
@@ -15,55 +15,6 @@ All OMSF positions are currently remote and we generally accept applications wor
 When applying, please use the application forms linked below. Please reach out to careers@omsf.io if you have any additional questions or need help.
 
 
-{{% h2 %}}
-## Senior Deep Learning Software Engineer (OpenFold)
-{{% /h2 %}}
-
-**PROJECT: [OPENFOLD](https://openfold.io)**
-
-**Role description**
-
-The OpenFold Consortium is looking for a talented deep learning software  engineer with a focus in AI in protein and molecular sciences to help steer the development of the next generation of biomolecular machine learning tools and the expansion of the OpenFold organization. Openfold is a non-profit pre-competitive consortium among Tech, Biotech
-and Academic institutions creating and supporting the next generation of ML tools for the biomolecular sciences with a focus on practical applications in drug discovery and product discovery in Agricultural and Synthetic Biology. OF is part of the OMSF foundation, and was co-founded by Prescient/Genentech, Arzeda, Outpace and Cyrus Bio with the support of
-Amazon – more recent members include NVIDIA on the Tech side and Bayer on the Pharma side.
-
-**Expected duties**
-
-The candidate’s overarching responsibilities will be to:
-- Supervise and support graduate students and scientists in undertaking bleeding-edge research projects focused on protein structure and conformation prediction, protein-ligand interactions, and protein design.
-- Maintain and manage the OpenFold codebase, set standards for team and community contributions, and implement modern software engineering practices.
-- Help set the scientific agenda of the OpenFold Consortium by actively interacting with industry partners and academic labs to identify emerging needs and prioritize high-value scientific directions.
-
-The candidate’s day-to-day responsibilities will be to:
-- Be an active member of a highly interdisciplinary team.
--Stay current with the ultra-fast paced nature of biomolecular machine learning.
-- Come up with new ideas and shepherd long-running projects that span software engineering, development of new machine learning algorithms, training of large-scale models, and methodical evaluation of computational experiments.
-- Help members of the research community use OpenFold, with time set aside as needed specifically for corporate members of OpenFold
-- Help members of the research community and corporate members with training and find-tuning of OpenFod models using their own data.
-- Strengthen external visibility and scientific excellence through publishing open-source code and engaging with the scientific community.
-
-**Qualifications**
-
-Required:
-- BS or MA/MS in computational biology, computer science / machine learning, or related quantitative fields.
-- Extensive software engineering experience in Python or other modern object-oriented programming language
-- Development,, training and deployment of complex deep learning models in any domain including computer vision, natural language, or other areas. Prior training of biological models is not required.
-- Strong interpersonal skills, excellent written and verbal communication, and the ability to work effectively both independently and in cross-functional teams.
-
-Preferred:
-- PhD in computational biology, computer science / machine learning, or related quantitative fields.
-- Knowledge of biology is preferred.
-- Experience in high-performance computing systems including on-prem clusters and cloud-based services is highly preferred.
-- Prior experience in technical leadership of small teams is preferred, for example as a technical lead on an ML project alongside a program or project manager; we are looking for technical leadership and thought leadership, not for a high count of reports in a formal HR sense.
-
-**Compensation**
-
-Base salary $120-165k/year depending on experience. Annual bonus based on clearly defined performance goals, percentage of base salary. Full benefits include health insurance, dental/vision, and 401(k).
-
-**Application**
-
-Please apply using [**this form**](https://forms.gle/EZ5RfrxTuKiEUSoQ6).
-
 
 {{% h2 %}}
 ## OMSF Expression of Interest

--- a/content/projects/host-project.md
+++ b/content/projects/host-project.md
@@ -22,7 +22,7 @@ The OMSF charges a fee to each Hosted Project to cover the costs of business adm
 {{% h3-green %}}
 How to become a Hosted Project?
 {{% /h3-green %}}
-1. Please apply by filling out this [form](https://forms.gle/AYYijckRW168c3WV9). The Board of Directors will review your application.
+1. Please reach out to info@omsf.io to start a conversation. The Board of Directors will review your application and make the final decision.
 
 2. If accepted, your team will work with OMSF to create an agreement defining the governance structure and membership plan for your supporting organizations (or individuals). This document will also specify the relationship and obligations between the Hosted Project and OMSF. If your project is already up and running, we will work with you to plan the migration of your project and its assets under the OMSF umbrella.
 


### PR DESCRIPTION
- Removed link to a Google Form on https://omsf.io/projects/host-project/ page.
- Removed the job ad for the deep learning position with OpenFold. 